### PR TITLE
Make Fmt.t abstract

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,6 @@
 ### (master)
 
+  + Internal: Future-proof Fmt API in case Fmt.t goes abstract (#1106) (Etienne Millon)
   + Fix the default value documentation for max-indent (#1105) (Guillaume Petiot)
   + Fix closing parenthesis exceeding the margin in function application (#1098) (Jules Aguillon)
   + Fix: missing break before attributes of Pmty_with (#1103) (Josh Berdine)

--- a/src/Cmts.ml
+++ b/src/Cmts.ml
@@ -484,7 +484,7 @@ let fmt_cmt (conf : Conf.t) ~fmt_code (cmt : Cmt.t) =
   let fmt_asterisk_prefixed_lines lines =
     vbox 1
       ( fmt "(*"
-      $ list_pn lines (fun ?prev:_ line ?next ->
+      $ list_pn lines (fun ~prev:_ line ~next ->
             match (line, next) with
             | "", None -> fmt ")"
             | _, None -> str line $ fmt "*)"
@@ -553,7 +553,7 @@ let fmt_cmts t (conf : Conf.t) ~fmt_code ?pro ?epi ?(eol = Fmt.fmt "@\n")
             fmt_if (line_dist cur_last_loc next_loc > 1) "\n"
         | _ -> noop
       in
-      list_pn groups (fun ?prev group ?next ->
+      list_pn groups (fun ~prev group ~next ->
           fmt_or_k (Option.is_none prev)
             (Option.call ~f:pro $ open_vbox 0)
             (fmt "@ ")
@@ -575,10 +575,9 @@ let fmt_before t conf ~fmt_code ?pro ?(epi = Fmt.break_unless_newline 1 0)
   fmt_cmts t conf t.cmts_before ~fmt_code ?pro ~epi ?eol ?adj
 
 let fmt_after t conf ~fmt_code ?(pro = Fmt.break_unless_newline 1 0) ?epi =
+  let open Fmt in
   let within = fmt_cmts t conf t.cmts_within ~fmt_code ~pro ?epi in
-  let after =
-    fmt_cmts t conf t.cmts_after ~fmt_code ~pro ?epi ~eol:Fmt.noop
-  in
+  let after = fmt_cmts t conf t.cmts_after ~fmt_code ~pro ?epi ~eol:noop in
   fun loc -> within loc $ after loc
 
 let fmt_within t conf ~fmt_code ?(pro = Fmt.break_unless_newline 1 0)
@@ -586,6 +585,7 @@ let fmt_within t conf ~fmt_code ?(pro = Fmt.break_unless_newline 1 0)
   fmt_cmts t conf t.cmts_within ~fmt_code ~pro ~epi ~eol:Fmt.noop
 
 let fmt t conf ~fmt_code ?pro ?epi ?eol ?adj loc =
+  let open Fmt in
   (* remove the before comments from the map first *)
   let before = fmt_before t conf ~fmt_code ?pro ?epi ?eol ?adj loc in
   (* remove the within comments from the map by accepting the continuation *)

--- a/src/Cmts.ml
+++ b/src/Cmts.ml
@@ -408,8 +408,9 @@ let init map_ast source asts comments_n_docstrings =
           if not (Location.compare loc Location.none = 0) then
             Hashtbl.set t.remaining ~key:loc ~data:()) ;
     if Conf.debug then (
+      let dump fs lt = Fmt.eval fs (Loc_tree.dump lt) in
       Format.eprintf "\nLoc_tree:\n%!" ;
-      Format.eprintf "@\n%a@\n@\n%!" (Fn.flip Loc_tree.dump) loc_tree ) ;
+      Format.eprintf "@\n%a@\n@\n%!" dump loc_tree ) ;
     let locs = Loc_tree.roots loc_tree in
     let cmts = CmtSet.of_list comments in
     match locs with
@@ -447,7 +448,7 @@ let preserve fmt_x x =
   let fs = Format.formatter_of_buffer buf in
   let save = !remove in
   remove := false ;
-  fmt_x x fs ;
+  Fmt.eval fs (fmt_x x) ;
   Format.pp_print_flush fs () ;
   remove := save ;
   Buffer.contents buf

--- a/src/Cmts.ml
+++ b/src/Cmts.ml
@@ -108,8 +108,7 @@ end = struct
                    (not (List.is_empty children))
                    "@,{" " }" (dump_ tree children) )))
     in
-    if Conf.debug then set_margin 100000000 $ dump_ tree tree.roots
-    else Fn.const ()
+    if Conf.debug then set_margin 100000000 $ dump_ tree tree.roots else noop
 end
 
 module Loc_tree = struct
@@ -556,7 +555,7 @@ let fmt_cmts t (conf : Conf.t) ~fmt_code ?pro ?epi ?(eol = Fmt.fmt "@\n")
       in
       list_pn groups (fun ~prev group ~next ->
           fmt_or_k (Option.is_none prev)
-            (Option.call ~f:pro $ open_vbox 0)
+            (fmt_opt pro $ open_vbox 0)
             (fmt "@ ")
           $ ( match group with
             | [] -> impossible "previous match"
@@ -567,9 +566,7 @@ let fmt_cmts t (conf : Conf.t) ~fmt_code ?pro ?epi ?(eol = Fmt.fmt "@\n")
                 $ maybe_newline ~next (List.last_exn group) )
           $ fmt_if_k (Option.is_none next)
               ( close_box
-              $ fmt_or_k eol_cmt
-                  (fmt_or_k adj_cmt adj eol)
-                  (Option.call ~f:epi) ))
+              $ fmt_or_k eol_cmt (fmt_or_k adj_cmt adj eol) (fmt_opt epi) ))
 
 let fmt_before t conf ~fmt_code ?pro ?(epi = Fmt.break_unless_newline 1 0)
     ?eol ?adj =

--- a/src/Fmt.ml
+++ b/src/Fmt.ml
@@ -88,6 +88,8 @@ let fmt_or_k cnd t_k f_k fs = if cnd then t_k fs else f_k fs
 
 let fmt_or cnd t f fs = fmt_or_k cnd (fmt t) (fmt f) fs
 
+let fmt_opt opt fs = match opt with Some k -> k fs | None -> ()
+
 (** Conditional on immediately following a line break -------------------*)
 
 let if_newline s fs = Format.pp_print_string_if_newline fs s

--- a/src/Fmt.ml
+++ b/src/Fmt.ml
@@ -25,6 +25,14 @@ let set_margin n fs = Format.pp_set_geometry fs ~max_indent:n ~margin:(n + 1)
 
 let set_max_indent n fs = Format.pp_set_max_newline_offset fs n
 
+let eval fs t = t fs
+
+let protect t ~on_error fs =
+  try t fs
+  with exn ->
+    Format.pp_print_flush fs () ;
+    on_error exn
+
 (** Debug of formatting -------------------------------------------------*)
 
 let pp_color_k color_code k fs =

--- a/src/Fmt.mli
+++ b/src/Fmt.mli
@@ -31,6 +31,12 @@ val set_margin : int -> t
 val set_max_indent : int -> t
 (** Set the maximum indentation. *)
 
+val eval : Format.formatter -> t -> unit
+(** [eval fs t] runs format thunk [t] outputting to [fs] *)
+
+val protect : t -> on_error:(exn -> unit) -> t
+(** Catch exceptions raised while formatting. *)
+
 (** Break hints and format strings --------------------------------------*)
 
 val break : int -> int -> t

--- a/src/Fmt.mli
+++ b/src/Fmt.mli
@@ -16,8 +16,8 @@ module Format = Format_
 type s = (unit, Format.formatter, unit) format
 (** Format strings that accept no arguments. *)
 
-type t = Format.formatter -> unit
-(** Format thunks, which accept a formatter buffer and write to it. *)
+type t
+(** Format thunks. *)
 
 val ( $ ) : t -> t -> t
 (** Format concatenation: [a $ b] formats [a], then [b]. *)

--- a/src/Fmt.mli
+++ b/src/Fmt.mli
@@ -19,6 +19,9 @@ type s = (unit, Format.formatter, unit) format
 type t = Format.formatter -> unit
 (** Format thunks, which accept a formatter buffer and write to it. *)
 
+val ( $ ) : t -> t -> t
+(** Format concatenation: [a $ b] formats [a], then [b]. *)
+
 val ( >$ ) : t -> ('b -> t) -> 'b -> t
 (** Pre-compose a format thunk onto a function returning a format thunk. *)
 
@@ -60,7 +63,7 @@ val list_fl : 'a list -> (first:bool -> last:bool -> 'a -> t) -> t
 (** Format a list using provided function for the elements, which is passed
     the flags indicating if the element is the first or last. *)
 
-val list_pn : 'a list -> (?prev:'a -> 'a -> ?next:'a -> t) -> t
+val list_pn : 'a list -> (prev:'a option -> 'a -> next:'a option -> t) -> t
 (** Format a list using provided function for the elements, which is passed
     the previous and next elements, if any. *)
 

--- a/src/Fmt.mli
+++ b/src/Fmt.mli
@@ -84,6 +84,10 @@ val fmt_or : bool -> s -> s -> t
 val fmt_or_k : bool -> t -> t -> t
 (** Conditionally select between two format thunks. *)
 
+val fmt_opt : t option -> t
+(** Optionally format. [fmt_opt (Some t)] is [t] and [fmt_opt None] is
+    [noop]. *)
+
 (** Conditional on immediately following a line break -------------------*)
 
 val if_newline : string -> t

--- a/src/Fmt_ast.ml
+++ b/src/Fmt_ast.ml
@@ -64,15 +64,13 @@ let compose_module {opn; pro; psp; bdy; cls; esp; epi} ~f =
 
 let protect =
   let first = ref true in
-  fun ast pp fs ->
-    try pp fs
-    with exc ->
-      if !first && Conf.debug then (
-        let bt = Caml.Printexc.get_backtrace () in
-        Format.pp_print_flush fs () ;
-        Caml.Format.eprintf "@\nFAIL@\n%a@\n%s@.%!" Ast.dump ast bt ;
-        first := false ) ;
-      raise exc
+  fun ast pp ->
+    Fmt.protect pp ~on_error:(fun exc ->
+        if !first && Conf.debug then (
+          let bt = Caml.Printexc.get_backtrace () in
+          Caml.Format.eprintf "@\nFAIL@\n%a@\n%s@.%!" Ast.dump ast bt ;
+          first := false ) ;
+        raise exc)
 
 let update_config ?quiet c l =
   {c with conf= List.fold ~init:c.conf l ~f:(Conf.update ?quiet)}

--- a/src/Fmt_ast.ml
+++ b/src/Fmt_ast.ml
@@ -284,7 +284,7 @@ let fmt_constant c ~loc ?epi const =
       let fmt_string_auto ?(break_on_newlines = false) mode s =
         let fmt_words ~epi mode s =
           let words = String.split (escape_string mode s) ~on:' ' in
-          let fmt_word ?prev:_ curr ?next =
+          let fmt_word ~prev:_ curr ~next =
             match next with
             | Some "" -> str curr $ str " "
             | Some _ -> str curr $ pre_break 1 " \\" 0
@@ -293,7 +293,7 @@ let fmt_constant c ~loc ?epi const =
           hovbox_if (List.length words > 1) 0 (list_pn words fmt_word $ epi)
         in
         let delim = ["@,"; "@;"] in
-        let fmt_line ~epi ?prev:_ curr ?next =
+        let fmt_line ~epi ~prev:_ curr ~next =
           let fmt_next next =
             let not_suffix suffix = not (String.is_suffix curr ~suffix) in
             let print_ln =
@@ -399,7 +399,7 @@ let docstring_epi ?(standalone = false) ?next ~floating ?epi =
 
 let fmt_docstring c ?standalone ?pro ?epi doc =
   list_pn (Option.value ~default:[] doc)
-    (fun ?prev:_ ({txt; loc}, floating) ?next ->
+    (fun ~prev:_ ({txt; loc}, floating) ~next ->
       let epi = docstring_epi ?standalone ?next ~floating ?epi in
       fmt_parsed_docstring c ~loc ?pro ~epi txt (parse_docstring ~loc txt))
 
@@ -417,7 +417,7 @@ let fmt_docstring_around_item' ?(force_before = false) ?(fit = false) c doc1
           | _ -> false)
       in
       let fmt_doc ?epi ?pro doc =
-        list_pn doc (fun ?prev:_ (parsed, ({txt; loc}, floating)) ?next ->
+        list_pn doc (fun ~prev:_ (parsed, ({txt; loc}, floating)) ~next ->
             let next = Option.map next ~f:snd in
             let epi = docstring_epi ?next ~floating ?epi in
             fmt_parsed_docstring c ~loc ~epi ?pro txt parsed)
@@ -1296,11 +1296,11 @@ and fmt_sequence c ?ext parens width xexp pexp_loc fmt_atrs =
       assert (Option.compare compare first_ext ext = 0)
   | _ -> impossible "at least two elements" ) ;
   let grps = List.group elts ~break in
-  let fmt_seq ?prev (ext, curr) ?next:_ =
+  let fmt_seq ~prev (ext, curr) ~next:_ =
     let f (_, prev) = fmt_sep c prev ext curr in
     Option.value_map prev ~default:noop ~f $ fmt_expression c curr
   in
-  let fmt_seq_list ?prev x ?next:_ =
+  let fmt_seq_list ~prev x ~next:_ =
     let f prev =
       let prev = snd (List.last_exn prev) in
       let ext, curr = List.hd_exn x in
@@ -3484,7 +3484,7 @@ and fmt_module c ?epi ?(can_sparse = false) keyword ?(eqty = "=") name xargs
   let blk_b = Option.value_map xbody ~default:empty ~f:(fmt_module_expr c) in
   let box_t = wrap_k blk_t.opn blk_t.cls in
   let box_b = wrap_k blk_b.opn blk_b.cls in
-  let fmt_arg ?prev:_ (name, arg_mtyp) ?next =
+  let fmt_arg ~prev:_ (name, arg_mtyp) ~next =
     let maybe_box k =
       match arg_mtyp with Some {pro= None; _} -> hvbox 0 k | _ -> k
     in

--- a/src/Fmt_odoc.ml
+++ b/src/Fmt_odoc.ml
@@ -106,7 +106,7 @@ let block_element_should_break elem next =
 (* Format a list of block_elements separated by newlines Inserts blank line
    depending on [block_element_should_break] *)
 let list_block_elem elems f =
-  list_pn elems (fun ?prev:_ elem ?next ->
+  list_pn elems (fun ~prev:_ elem ~next ->
       let elem = elem.Location_.value in
       let break =
         match next with

--- a/src/Translation_unit.ml
+++ b/src/Translation_unit.ml
@@ -236,7 +236,7 @@ let with_optional_box_debug ~box_debug k =
 let with_buffer_formatter ~buffer_size k =
   let buffer = Buffer.create buffer_size in
   let fs = Format_.formatter_of_buffer buffer in
-  k fs ;
+  Fmt.eval fs k ;
   Format_.pp_print_flush fs () ;
   if Buffer.length buffer > 0 then Format_.pp_print_newline fs () ;
   Buffer.contents buffer

--- a/src/import/Import.ml
+++ b/src/import/Import.ml
@@ -30,8 +30,6 @@ include Stdio
 
 let ( >> ) f g x = g (f x)
 
-let ( $ ) f g x = f x ; g x
-
 let impossible msg = failwith msg
 
 let user_error msg kvs =

--- a/src/import/Import.mli
+++ b/src/import/Import.mli
@@ -37,10 +37,6 @@ val ( >> ) : ('a -> 'b) -> ('b -> 'c) -> 'a -> 'c
 (** Composition of functions: [(f >> g) x] is exactly equivalent to
     [g (f (x))]. Left associative. *)
 
-val ( $ ) : ('a -> unit) -> ('a -> 'b) -> 'a -> 'b
-(** Sequential composition of functions: [(f $ g) x] is exactly equivalent to
-    [(f x) ; (g x)]. Left associative. *)
-
 val impossible : string -> _
 (** Indicate why the call is expected to be impossible. *)
 


### PR DESCRIPTION
@emillon PR to https://github.com/ocaml-ppx/ocamlformat/pull/1106

I wanted to check if https://github.com/ocaml-ppx/ocamlformat/pull/1106 was not missing anything and accidentally did the work.

Added `Fmt.protect` to implement `protect` in `Fmt_ast.ml`, it's used to print debug.
Added `Fmt.fmt_opt` to format `Fmt.t option` values.